### PR TITLE
[Feat] 시간선택UI 구현 및 라우팅

### DIFF
--- a/Front/src/components/Menu.js
+++ b/Front/src/components/Menu.js
@@ -3,17 +3,19 @@ import { StyleSheet, Text, View, Image } from "react-native";
 
 import simya from "../../assets/심야식당.jpeg";
 
-const Menu = ({menu}) => {
+const Menu = ({ menu }) => {
   return (
     <View style={styles.menu}>
       <View style={styles.menuText}>
-        <Text style={styles.menuName}>육전</Text>
-        <Text style={styles.menuDesc}>
-          얇게 썬 쇠고기를 달걀 반죽에 담그고 튀긴 한국식 하와이 요리입니다.
-        </Text>
-        <Text style={styles.menuPrice}>15000원</Text>
+        <Text style={styles.menuName}>{menu.menuName}</Text>
+        <Text style={styles.menuDesc}>{menu.menuDesc}</Text>
+        <Text style={styles.menuPrice}>{menu.price.toLocaleString()}원</Text>
       </View>
-      <Image style={styles.menuImg} source={simya} resizeMode="cover"></Image>
+      <Image
+        style={styles.menuImg}
+        source={menu.menuImage}
+        resizeMode="cover"
+      ></Image>
     </View>
   );
 };

--- a/Front/src/components/TimeTable.js
+++ b/Front/src/components/TimeTable.js
@@ -35,10 +35,11 @@ const TimeTable = ({onTimeChange}) => {
             style={[
               styles.timeSlot,
               {
-                backgroundColor: timeSlot.available ? "#FFD88E" : "#b3b3b3",
+                backgroundColor: timeSlot.available ? "#FFD88E" : "#D9D9D9",
               },
             ]}
             onPress={() => handleTimeChange(timeSlot.value)}
+            disabled = {!timeSlot.available}
           >
             <Text style={styles.timeSlotText}>{timeSlot.label}</Text>
           </TouchableOpacity>
@@ -55,10 +56,10 @@ const styles = StyleSheet.create({
     alignItems: "center",
     paddingVertical: 10,
     marginVertical: 10,
-    backgroundColor: "#e1e1e1",
+    backgroundColor: "#ECECEC",
   },
   timeSlotsContainer: {
-    width: "90%",
+    width: "91%",
     flexDirection: "row",
     flexWrap: "wrap",
   },

--- a/Front/src/components/TimeTable.js
+++ b/Front/src/components/TimeTable.js
@@ -1,0 +1,76 @@
+import { useState } from "react";
+import { View, Text, StyleSheet, TouchableOpacity } from "react-native";
+
+const TimeTable = ({onTimeChange}) => {
+
+  //임시 시간 목록
+  const timeSlots = [
+    { label: "17:00", value: "17:00", available: true },
+    { label: "17:30", value: "17:30", available: true },
+    { label: "18:00", value: "18:00", available: true },
+    { label: "18:30", value: "18:30", available: false },
+    { label: "19:00", value: "19:00", available: false },
+    { label: "19:30", value: "19:30", available: true },
+    { label: "20:00", value: "20:00", available: false },
+    { label: "20:30", value: "20:30", available: false },
+    { label: "21:00", value: "21:00", available: true },
+    { label: "21:30", value: "21:30", available: false },
+    { label: "22:00", value: "22:00", available: false },
+    { label: "22:30", value: "22:30", available: false },
+    { label: "23:00", value: "23:00", available: false },
+    { label: "23:30", value: "23:30", available: false },
+    { label: "24:00", value: "24:00", available: false },
+  ];
+
+  const handleTimeChange = (selectTime) => {
+    onTimeChange(selectTime);
+  };
+
+  return (
+    <View style={styles.timeContainer}>
+      <View style={styles.timeSlotsContainer}>
+        {timeSlots.map((timeSlot, index) => (
+          <TouchableOpacity
+            key={index}
+            style={[
+              styles.timeSlot,
+              {
+                backgroundColor: timeSlot.available ? "#FFD88E" : "#b3b3b3",
+              },
+            ]}
+            onPress={() => handleTimeChange(timeSlot.value)}
+          >
+            <Text style={styles.timeSlotText}>{timeSlot.label}</Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  timeContainer: {
+    width: "100%",
+    flexDirection: "column",
+    alignItems: "center",
+    paddingVertical: 10,
+    marginVertical: 10,
+    backgroundColor: "#e1e1e1",
+  },
+  timeSlotsContainer: {
+    width: "90%",
+    flexDirection: "row",
+    flexWrap: "wrap",
+  },
+  timeSlot: {
+    padding: 10,
+    paddingHorizontal: 15,
+    margin: 5,
+    borderRadius: 5,
+  },
+  timeSlotText: {
+    fontSize: 16,
+  },
+});
+
+export default TimeTable;

--- a/Front/src/components/TimeTable.js
+++ b/Front/src/components/TimeTable.js
@@ -1,8 +1,7 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { View, Text, StyleSheet, TouchableOpacity } from "react-native";
 
-const TimeTable = ({onTimeChange}) => {
-
+const TimeTable = ({ onTimeChange }) => {
   //임시 시간 목록
   const timeSlots = [
     { label: "17:00", value: "17:00", available: true },
@@ -22,8 +21,71 @@ const TimeTable = ({onTimeChange}) => {
     { label: "24:00", value: "24:00", available: false },
   ];
 
-  const handleTimeChange = (selectTime) => {
-    onTimeChange(selectTime);
+  const [isStartTimeSelected, setIsStartTimeSelected] = useState(false);
+  const [startTime, setStartTime] = useState();
+  const [lastTime, setLastTime] = useState();
+  const [selectedTimes, setSelectedTimes] = useState([]);
+
+  useEffect(() => {
+    if(startTime && lastTime){
+      const result = startTime + " - " + lastTime;
+      onTimeChange(result);
+    }
+  },[startTime, lastTime, onTimeChange])
+
+  const handleTimeChange = (selectedTime) => {
+    const selectedIndex = timeSlots.findIndex(
+      (slot) => slot.value === selectedTime
+    );
+    if (!isStartTimeSelected) {
+      setStartTime(selectedTime);
+      setIsStartTimeSelected(true);
+      setSelectedTimes([selectedTime]);
+    } else {
+      // 마지막 시간을 설정하기 전에 비활성화된 시간이 있는지 확인
+      const isUnavailableTimeInBetween = timeSlots
+        .slice(
+          timeSlots.findIndex((slot) => slot.value === startTime) + 1,
+          selectedIndex
+        )
+        .some((slot) => !slot.available);
+
+      if (isUnavailableTimeInBetween) {
+        // 비활성화된 시간이 있으면 마지막 시간을 설정하지 않고 시작 시간을 업데이트
+        setStartTime(selectedTime);
+        setSelectedTimes([selectedTime]);
+      } else {  // 마지막 시간을 설정하고 상태를 초기화
+        const startDateTime = new Date(`2023-10-10T${startTime}:00`);
+        const selectedDateTime = new Date(`2023-10-10T${selectedTime}:00`);
+
+        if (selectedDateTime < startDateTime) {
+          // 선택된 시간이 시작 시간보다 빠르면 시작 시간으로 설정
+          setStartTime(selectedTime);
+          setLastTime("");
+          setSelectedTimes([selectedTime]);
+        } else {
+          //선택된 시간 + 30분
+          selectedDateTime.setMinutes(selectedDateTime.getMinutes() + 30);
+          const formattedTime = selectedDateTime.getMinutes() < 10 ? `0${selectedDateTime.getMinutes()}` : selectedDateTime.getMinutes();
+          console.log(selectedDateTime.getHours() + ":" + formattedTime);
+          setLastTime(selectedDateTime.getHours() + ":" + formattedTime);
+          setIsStartTimeSelected(false);
+
+          //선택된 시간구간 색깔 바꿔주기 위해 리스트에 추가
+          const selectedIndices = [
+            timeSlots.findIndex((slot) => slot.value === startTime),
+            timeSlots.findIndex((slot) => slot.value === selectedTime),
+          ];
+          const newSelectedTimes = timeSlots
+            .slice(
+              Math.min(...selectedIndices),
+              Math.max(...selectedIndices) + 1
+            )
+            .map((slot) => slot.value);
+          setSelectedTimes(newSelectedTimes);
+        }
+      }
+    }
   };
 
   return (
@@ -35,11 +97,15 @@ const TimeTable = ({onTimeChange}) => {
             style={[
               styles.timeSlot,
               {
-                backgroundColor: timeSlot.available ? "#FFD88E" : "#D9D9D9",
+                backgroundColor: selectedTimes.includes(timeSlot.value)
+                  ? "#FFA07A"
+                  : timeSlot.available
+                  ? "#FFD88E"
+                  : "#D9D9D9",
               },
             ]}
             onPress={() => handleTimeChange(timeSlot.value)}
-            disabled = {!timeSlot.available}
+            disabled={!timeSlot.available}
           >
             <Text style={styles.timeSlotText}>{timeSlot.label}</Text>
           </TouchableOpacity>

--- a/Front/src/pages/BarDetail.js
+++ b/Front/src/pages/BarDetail.js
@@ -17,13 +17,15 @@ import star from "../../assets/star.png";
 import Menu from "../components/Menu";
 import TimeTable from "../components/TimeTable";
 
-const BarDetail = ({ bar }) => {
+const BarDetail = ({ route }) => {
   const [date, setDate] = useState(new Date());
   const [open, setOpen] = useState(false);
   const [mode, setMode] = useState("date");
   const [time, setTime] = useState("11:00");
   const [showForm, setShowForm] = useState(false);
   const [text, setText] = useState("");
+
+  const bar = route.params.bar;
 
   const showReservationForm = () => {
     setShowForm(true);
@@ -63,40 +65,34 @@ const BarDetail = ({ bar }) => {
     <ScrollView contentContainerStyle={styles.container}>
       <View style={styles.headerContainer}>
         <View style={styles.headerTopContainer}>
-          <Text style={styles.title}>백수씨 심야식당</Text>
+          <Text style={styles.title}>{bar.name}</Text>
           <View style={styles.ratingContainer}>
             <Image source={star} style={styles.starImg} resizeMode="contain" />
-            <Text style={styles.rating}>4.3</Text>
+            <Text style={styles.rating}>{bar.rating}</Text>
           </View>
         </View>
-        <Text style={styles.tags}>#이자카야 #분위기좋음 #안주맛있음</Text>
+        <Text style={styles.tags}>
+          {bar.tags.map((tag, index) => (
+            <Text key={index}>{tag}{" "}</Text>
+          ))}
+        </Text>
       </View>
 
       <View style={styles.imageContainer}>
-        <Image source={simya} style={styles.image} resizeMode="contain" />
+        <Image source={bar.image} style={styles.image} resizeMode="contain" />
       </View>
+
       <View style={styles.content}>
         <View style={styles.timetable}>
-          <View style={styles.detailContainer}>
-            <Text>
-              저희 백수씨 심야식당은 사람들이 편하게 먹을 수 있는 안주거리와
-              산지의 해산물을 위주로 부담되지 않는 가격대의 '실내포장마차' 를
-              방향성으로 잡고 있습니다. 강원도 동해, 남해 서해 등의 현지 특산물,
-              해산물 등을 산지 직송으로 당일 배송받아 서울에서 판매하는 해산물,
-              퓨전음식 '소주집' 입니다. 육류 메뉴로는 가장 많이 나가는 '육전' 이
-              있으며 해산물 요리로는 속초에서 직접 공수받아 조리하는 '홍게탕'
-              '백합조개탕' , 서해 남해 등에서 공수받는 돌문어, 청어, 참소라,
-              골뱅이 등등 메뉴판에는 없는 그날그날 들어온 해산물들을 직원 추천을
-              통해 손님들에게 제공하며 옛 감성의 음악과 인테리어 안에 좋은
-              추억을 가져갈 수 있는 소박한 식당입니다.
-            </Text>
+          <View style={styles.introContainer}>
+            <Text>{bar.introduction}</Text>
           </View>
 
           <View style={styles.menuContainer}>
             <Text style={styles.menuTitle}>대표메뉴</Text>
             <View style={styles.menuTitleLine}></View>
-            <Menu />
-            <Menu />
+            <Menu menu={bar.menu[0]} />
+            <Menu menu={bar.menu[0]} />
           </View>
 
           <View style={styles.reservationContainer}>
@@ -126,28 +122,8 @@ const BarDetail = ({ bar }) => {
                 <View style={styles.timeContainer}>
                   <Text style={styles.timeTitle}>시간</Text>
                   <Text style={styles.timeText}>{time}</Text>
-                  {/* <Picker
-                    style={styles.timePicker}
-                    selectedValue={time}
-                    onValueChange={handleTimeChange}
-                  >
-                    <Picker.Item label="11:00" value="11:00" />
-                    <Picker.Item label="12:00" value="12:00" />
-                    <Picker.Item label="13:00" value="13:00" />
-                    <Picker.Item label="14:00" value="14:00" />
-                    <Picker.Item label="15:00" value="15:00" />
-                    <Picker.Item label="16:00" value="16:00" />
-                    <Picker.Item label="17:00" value="17:00" />
-                    <Picker.Item label="18:00" value="18:00" />
-                    <Picker.Item label="19:00" value="19:00" />
-                    <Picker.Item label="20:00" value="20:00" />
-                    <Picker.Item label="21:00" value="21:00" />
-                    <Picker.Item label="22:00" value="22:00" />
-                    <Picker.Item label="23:00" value="23:00" />
-                  </Picker> */}
-                  
                 </View>
-                <TimeTable onTimeChange={handleTimeChange}/>
+                <TimeTable onTimeChange={handleTimeChange} />
                 <View style={styles.requestContainer}>
                   <Text>요청사항</Text>
                   <TextInput
@@ -260,8 +236,8 @@ const styles = StyleSheet.create({
     alignItems: "center",
     paddingVertical: 10,
   },
-  timeTitle:{},
-  timeText:{
+  timeTitle: {},
+  timeText: {
     marginHorizontal: 10,
     paddingHorizontal: 10,
     paddingVertical: 5,

--- a/Front/src/pages/BarDetail.js
+++ b/Front/src/pages/BarDetail.js
@@ -9,12 +9,13 @@ import {
   TextInput,
   TouchableOpacity,
 } from "react-native";
-import { Picker } from "@react-native-picker/picker";
+import DateTimePicker from "@react-native-community/datetimepicker";
 
 import simya from "../../assets/심야식당.jpeg";
 import star from "../../assets/star.png";
 
 import Menu from "../components/Menu";
+import TimeTable from "../components/TimeTable";
 
 const BarDetail = ({ bar }) => {
   const [date, setDate] = useState(new Date());
@@ -32,9 +33,20 @@ const BarDetail = ({ bar }) => {
     setTime(selectTime);
   };
 
+  // Datepicker
+  const onChange = (event, selectedDate) => {
+    const currentDate = selectedDate || date;
+    setDate(currentDate);
+    setOpen(false);
+  };
+
   const openMode = (currentMode) => {
     setOpen(true);
     setMode(currentMode);
+  };
+
+  const openDatepicker = () => {
+    openMode("date");
   };
 
   const onChangeText = (text) => {
@@ -90,20 +102,31 @@ const BarDetail = ({ bar }) => {
           <View style={styles.reservationContainer}>
             {showForm && (
               <>
+                <View style={styles.dateContainer}>
+                  <Text style={styles.dateTitle}>날짜</Text>
+                  <TouchableOpacity
+                    onPress={openDatepicker}
+                    style={styles.datePicker}
+                  >
+                    <Text style={styles.dateText}>
+                      {date.toLocaleDateString()}
+                      &#40;{dayOfWeek(date.getDay())}&#41;
+                    </Text>
+                  </TouchableOpacity>
+                </View>
                 {open && (
                   <DateTimePicker
                     testID="dateTimePicker"
                     value={date}
                     mode={mode}
-                    is24Hour={true}
                     display="calendar"
                     onChange={onChange}
-                    on
                   />
                 )}
                 <View style={styles.timeContainer}>
-                  <Text>시간</Text>
-                  <Picker
+                  <Text style={styles.timeTitle}>시간</Text>
+                  <Text style={styles.timeText}>{time}</Text>
+                  {/* <Picker
                     style={styles.timePicker}
                     selectedValue={time}
                     onValueChange={handleTimeChange}
@@ -121,8 +144,10 @@ const BarDetail = ({ bar }) => {
                     <Picker.Item label="21:00" value="21:00" />
                     <Picker.Item label="22:00" value="22:00" />
                     <Picker.Item label="23:00" value="23:00" />
-                  </Picker>
+                  </Picker> */}
+                  
                 </View>
+                <TimeTable onTimeChange={handleTimeChange}/>
                 <View style={styles.requestContainer}>
                   <Text>요청사항</Text>
                   <TextInput
@@ -233,6 +258,14 @@ const styles = StyleSheet.create({
   timeContainer: {
     flexDirection: "row",
     alignItems: "center",
+    paddingVertical: 10,
+  },
+  timeTitle:{},
+  timeText:{
+    marginHorizontal: 10,
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+    fontWeight: "bold",
   },
   reservationContainer: {},
   requestContainer: {

--- a/Front/src/pages/Main.js
+++ b/Front/src/pages/Main.js
@@ -2,15 +2,58 @@ import { Text, View, Button, StyleSheet, StatusBar } from "react-native";
 
 import { useNavigation } from "@react-navigation/native";
 
+import simya from "../../assets/심야식당.jpeg";
+
 const Main = () => {
   const navigation = useNavigation();
+
+  //더미데이터
+  const bars = {
+    simya: {
+      name: "백수씨 심야식당",
+      address: "중구 충무로5가 82-10",
+      image: simya,
+      rating: 4.3,
+      tags: ["#이자카야", "#분위기좋음", "#안주맛있음"],
+      introduction: 
+      `저희 백수씨 심야식당은 사람들이 편하게 먹을 수 있는 안주거리와 산지의 해산물을 위주로 부담되지 않는 가격대의 '실내포장마차' 를 방향성으로 잡고 있습니다. 
+강원도 동해, 남해 서해 등의 현지 특산물, 해산물 등을 산지 직송으로 당일 배송받아 서울에서 판매하는 해산물, 퓨전음식 '소주집' 입니다. 
+육류 메뉴로는 가장 많이 나가는 '육전'이 있으며 해산물 요리로는 속초에서 직접 공수받아 조리하는 '홍게탕', '백합조개탕' , 서해 남해 등에서 공수받는 돌문어, 청어, 참소라, 골뱅이 등등 메뉴판에는 없는 그날그날 들어온 해산물들을 직원 추천을 통해 손님들에게 제공하며 옛 감성의 음악과 인테리어 안에 좋은 추억을 가져갈 수 있는 소박한 식당입니다.`,
+      menu: [
+        {
+          menuName: "육전",
+          menuImage: simya,
+          menuDesc: `얇게 썬 쇠고기를 달걀 반죽에 담그고 튀긴 한국식 하와이 요리입니다.`,
+          price: 15000,
+        },
+      ],
+      timeSlots: [
+        { label: "17:00", value: "17:00", available: true },
+        { label: "17:30", value: "17:30", available: true },
+        { label: "18:00", value: "18:00", available: true },
+        { label: "18:30", value: "18:30", available: false },
+        { label: "19:00", value: "19:00", available: false },
+        { label: "19:30", value: "19:30", available: true },
+        { label: "20:00", value: "20:00", available: false },
+        { label: "20:30", value: "20:30", available: false },
+        { label: "21:00", value: "21:00", available: true },
+        { label: "21:30", value: "21:30", available: false },
+        { label: "22:00", value: "22:00", available: false },
+        { label: "22:30", value: "22:30", available: false },
+        { label: "23:00", value: "23:00", available: false },
+        { label: "23:30", value: "23:30", available: false },
+        { label: "24:00", value: "24:00", available: false },
+      ],
+    },
+  };
+
   return (
     <View style={styles.container}>
       <Text>끼리끼리</Text>
       <Button
         title="식당 상세페이지"
         onPress={() => {
-          navigation.navigate("식당 상세");
+          navigation.navigate("식당 상세", { bar: bars.simya });
         }}
       />
       <StatusBar style="auto" />


### PR DESCRIPTION
## 진행 배경
 - 술집 상세페이지 내 시간 선택 기능&UI필요
 - 라우팅 및 페이지 간 데이터 전송 필요
   - 메인(술집 리스트)페이지에서 특정 술집 클릭 시 해당 상세페이지에 술집 정보를 넘겨줄 수 있어야함 

## 구현 내용
 - 술집 상세페이지 내 시간 선택 UI 구현
 - Navigatior와 route.params이용하여 페이지 간 데이터 전송
   - 상세페이지 정보의 경우 메인에서 전달한 술집 정보를 받아와 해당 상세정보 출력하도록 함

## 참고 사항
 - 라우팅 활용 관련: 팀 노션의 'React Native 라우팅에 대하여' 문서를 참고해주세요.

## 추후 진행 예정 사항
 - 시간 선택의 경우 이용 시간 상한선이 존재하도록 수정
 - UI 개선작업